### PR TITLE
chore: automate repo setup and fix some startup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cp -r apps/core/.env.example apps/core/.env.dev
 # Para utilizar o localstack e persistir os logs, instale
 https://github.com/localstack/awscli-local
 
+Atenção: O `awscli-local` é um wrapper para o AWS CLI.
+Certifique-se de que o AWS CLI original esteja instalado em seu sistema.
+(Ao instalar o awscli-local da maneira recomendada, o awscli normalmente já é instalado)
+
 # De `start` no projeto
 pnpm dev
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,11 @@ pnpm i
 # Rode o comando `build` para que o código tenha acesso as libs internas
 pnpm build
 
-# Suba o container docker
-docker compose up -d
-
 # Realize a copia das variaveis de ambiente para o arquivo .env
 cp -r apps/core/.env.example apps/core/.env.dev
 
 # Para utilizar o localstack e persistir os logs, instale
 https://github.com/localstack/awscli-local
-
-# E rode o seguinte comando
-awslocal s3api create-bucket --bucket ufabc-next
 
 # De `start` no projeto
 pnpm dev

--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -9,10 +9,10 @@ BACKOFFICE_EMAILS="next.dev@aluno.ufabc.edu.br"
 
 NODE_OPTIONS=--enable-source-maps --max-old-space-size=2048
 
-USE_LOCALSTACK=
+USE_LOCALSTACK=true
 
 OAUTH_GOOGLE_CLIENT_ID=
-OAUTH_GOOGLE_SECRET=
+OAUTH_GOOGLE_SECRET=abcdefghijklmnopqrstuvwxyz
 
 AXIOM_TOKEN=
 AXION_DATASET=

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "pnpm@9.7.0",
   "type": "module",
   "scripts": {
-    "dev": "turbo run dev --parallel",
+    "dev": "pnpm run services:up && turbo run dev --parallel",
+    "services:up": "docker compose up -d && awslocal s3api create-bucket --bucket ufabc-next",
     "build": "turbo run build",
     "tsc": "turbo run tsc --parallel",
     "start": "turbo run start",


### PR DESCRIPTION
Este PR melhora a experiência para novos devs que desejam inicializar o projeto:

1 - Adiciona um novo script que substitui a necessidade de rodar o comando do docker compose e da criacao do bucket aws manualmente

2 - Preenche duas variáveis do '.env.example' que são necessárias para inicializar o projeto