### PR TITLE
Adiciona o campo de `EADCount` na payload das reviews de professor para alimentar o `filtro EAD` no front-end

### DIFF
--- a/apps/core/src/routes/entities/teachers/index.ts
+++ b/apps/core/src/routes/entities/teachers/index.ts
@@ -121,6 +121,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 function getMean(value: any[], key?: string): any {
   const count = value.reduce((sum, v) => sum + v.count, 0);
   const amount = value.reduce((sum, v) => sum + v.amount, 0);
+  const eadCount = value.reduce((sum, v) => sum + v.eadCount, 0)
   const simpleSum = value
     .filter((v) => v.cr_medio != null)
     .reduce((sum, v) => sum + v.amount * v.cr_medio, 0);
@@ -130,6 +131,7 @@ function getMean(value: any[], key?: string): any {
     cr_medio: simpleSum / amount,
     cr_professor: value.reduce((sum, v) => sum + v.numericWeight, 0) / amount,
     count,
+    eadCount,
     amount: amount,
     numeric: value.reduce((sum, v) => sum + v.numeric, 0),
     numericWeight: value.reduce((sum, v) => sum + v.numericWeight, 0),

--- a/apps/core/src/routes/entities/teachers/service.ts
+++ b/apps/core/src/routes/entities/teachers/service.ts
@@ -28,6 +28,21 @@ export async function rawReviews(teacherId: Types.ObjectId) {
         },
         cr_medio: { $avg: '$cr_acumulado' },
         count: { $sum: 1 },
+        eadCount: {
+          $sum: {
+            $cond: [
+              {
+                $in: ['$season', [
+                  '2020:1', '2020:2', '2020:3',
+                  '2021:1', '2021:2', '2021:3',
+                  '2022:1', '2022:2'
+                ]]
+              },
+              1,
+              0
+            ]
+          }
+        },
         crs: { $push: '$cr_acumulado' },
         weight: {
           $first: {
@@ -62,6 +77,7 @@ export async function rawReviews(teacherId: Types.ObjectId) {
         _id: 1,
         cr_medio: 1,
         count: 1,
+        eadCount: 1,
         weight: 1,
         crs: 1,
         amount: { $size: '$crs' },
@@ -75,6 +91,7 @@ export async function rawReviews(teacherId: Types.ObjectId) {
             conceito: '$_id.conceito',
             weight: '$weight',
             count: '$count',
+            eadCount: '$eadCount',
             cr_medio: '$cr_medio',
             numeric: { $multiply: ['$amount', '$cr_medio'] },
             numericWeight: { $multiply: ['$amount', '$weight'] },
@@ -94,6 +111,7 @@ export async function rawReviews(teacherId: Types.ObjectId) {
         numeric: 1,
         amount: 1,
         count: 1,
+        eadCount: 1,
         cr_professor: {
           $cond: [
             { $eq: ['$amount', 0] },


### PR DESCRIPTION
Aqui a decisao foi manter as modificacoes o mais simples possivel para diminuir a chance de qualquer efeito domino de erros.

Acabei retornando o eadCount independentemente do filtro no front-end estar ativado ou nao, pois penso que em situacoes extremas, como um celular com conexao limitada, isso pode fazer uma boa diferenca na responsividade do filtro. Quando o usuario ativar o filtro, teria que ocorrer mais uma request ao back-end caso fosse implementado como query parameters (mesmo que o front-end tenha cache).

No momento, penso que essa foi a melhor forma de ter implementado, mas vamos discutindo. Fico aberto a sugestoes glr!