### PR TITLE
Adiciona eadCount no campo especifico de cada materia.

### DIFF
--- a/apps/core/src/routes/entities/teachers/service.ts
+++ b/apps/core/src/routes/entities/teachers/service.ts
@@ -102,6 +102,7 @@ export async function rawReviews(teacherId: Types.ObjectId) {
         numeric: { $sum: { $multiply: ['$amount', '$cr_medio'] } },
         amount: { $sum: '$amount' },
         count: { $sum: '$count' },
+        eadCount: { $sum: '$eadCount'}
       },
     },
     {


### PR DESCRIPTION
Estava faltando adicionar o eadCount total de cada materia específica.

Porque estava faltando: para atualizar o chip de conceitos de cada materia específica quando o filtro está ativado

![image](https://github.com/user-attachments/assets/faffd407-5314-45b7-af6f-8adf4a57df78)
