### PR TITLE
Adiciona rota para verificar erros em fila

### DIFF
--- a/apps/core/src/queue/Job.ts
+++ b/apps/core/src/queue/Job.ts
@@ -67,6 +67,21 @@ export class Jobs implements JobImpl {
     return this.queues[JOBS[jobName].queue] as TypeSafeQueue<TData, TResult>;
   }
 
+  async getFailedByReason(queueName: string, reason: string, batchSize = 500) {
+    const queue = this.queues[queueName];
+    const failedJobs = await queue.getFailed(batchSize);
+
+    const filteredJobs = failedJobs
+      .filter((job) => job.failedReason.includes(reason))
+      .map((j) => ({
+        id: j.id,
+        name: j.name,
+        data: j.data,
+      }));
+
+    return filteredJobs;
+  }
+
   async setup() {
     const isTest = this.app.config.NODE_ENV === 'test';
     if (isTest) {

--- a/apps/core/src/queue/jobs/user-enrollments.job.ts
+++ b/apps/core/src/queue/jobs/user-enrollments.job.ts
@@ -498,7 +498,7 @@ function getTurnoFromTurma(turma: string): string {
 }
 
 function extractTurma(turmaRaw: string): string | null {
-  // Remove leading 'F' if present (puta edge case)
+  // Remove leading 'F' if present (rare edge case)
   const turmaStr = turmaRaw.startsWith('F') ? turmaRaw.slice(1) : turmaRaw;
   const match = turmaStr.match(/^[A-Z]([A-Z]\d{0,2})/i);
   return match ? match[1] : null;

--- a/apps/core/src/queue/jobs/user-enrollments.job.ts
+++ b/apps/core/src/queue/jobs/user-enrollments.job.ts
@@ -380,18 +380,15 @@ async function buildEnrollmentFromSubject(
     throw new Error('Missing turma');
   }
 
-  const turmaMatch = baseData.turma
-    .toUpperCase()
-    .match(/^[A-Z]([A-Z]\d{0,2})/i);
+  const turma = extractTurma(baseData.turma);
 
-  if (!turmaMatch) {
+  if (!turma) {
     log.warn(
       { turmaRaw: baseData.turma, component, baseData },
       'Turma format did not match expected pattern',
     );
     throw new Error('Invalid turma format', { cause: baseData.turma });
   }
-  const turma = turmaMatch[1];
 
   const UFClassroomCode = `${baseData.turno?.slice(0, 1).toUpperCase()}${turma.toUpperCase()}${component.codigo}${baseData.campus?.slice(0, 2)}`;
 
@@ -498,4 +495,11 @@ function getCampusFromTurma(turma: string): string {
 
 function getTurnoFromTurma(turma: string): string {
   return turma.slice(0, 1).toUpperCase() === 'N' ? 'noturno' : 'diurno';
+}
+
+function extractTurma(turmaRaw: string): string | null {
+  // Remove leading 'F' if present (puta edge case)
+  const turmaStr = turmaRaw.startsWith('F') ? turmaRaw.slice(1) : turmaRaw;
+  const match = turmaStr.match(/^[A-Z]([A-Z]\d{0,2})/i);
+  return match ? match[1] : null;
 }

--- a/apps/core/src/routes/backoffice/index.ts
+++ b/apps/core/src/routes/backoffice/index.ts
@@ -44,6 +44,32 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       };
     },
   );
+
+  app.get(
+    '/jobs/failed',
+    {
+      preHandler: (request, reply) => request.isAdmin(reply),
+    },
+    async (request, reply) => {
+      const { reason, batchSize, queue } = request.query as {
+        reason?: string;
+        batchSize?: number;
+        queue: string;
+      };
+
+      if (!reason) {
+        return reply.badRequest('Missing reason');
+      }
+
+      const failedJobs = await app.job.getFailedByReason(
+        queue,
+        reason,
+        batchSize ?? 500,
+      );
+
+      return reply.send(failedJobs);
+    },
+  );
 };
 
 export default plugin;


### PR DESCRIPTION
This pull request introduces enhancements to job handling and error filtering in the queue system, refactors code for better readability and modularity, and adds a new API endpoint for querying failed jobs. The most important changes include the addition of a method to filter failed jobs by reason, the extraction of reusable logic for parsing `turma` strings, and the implementation of the new `/jobs/failed` API route.

### Enhancements to job handling:

* [`apps/core/src/queue/Job.ts`](diffhunk://#diff-1c9d3c7ee98a36eb2d2c3c41ce81ade8385642b801f803eb2f31db42462f4bafR70-R84): Added the `getFailedByReason` method to filter failed jobs by their failure reason and return relevant details such as `id`, `name`, and `data`.

### Code refactoring:

* [`apps/core/src/queue/jobs/user-enrollments.job.ts`](diffhunk://#diff-46553b62588fdb88c2735ac6fe2ddbb1da7fa288bc72c985a268f1bc0c65cdcdL383-L394): Refactored the logic for parsing `turma` strings by introducing the `extractTurma` helper function, improving code modularity and readability. [[1]](diffhunk://#diff-46553b62588fdb88c2735ac6fe2ddbb1da7fa288bc72c985a268f1bc0c65cdcdL383-L394) [[2]](diffhunk://#diff-46553b62588fdb88c2735ac6fe2ddbb1da7fa288bc72c985a268f1bc0c65cdcdR499-R505)

### New API endpoint:

* [`apps/core/src/routes/backoffice/index.ts`](diffhunk://#diff-b7d1a19dc98000841d81974601c922e1d1db36222c5f2266c9db6fd5a6b3402cR47-R72): Added a new `/jobs/failed` API route to query failed jobs based on a specified reason, queue, and optional batch size, with admin-only access enforced via `preHandler`.