### PR TITLE
feat: improve comments query

### DIFF
--- a/apps/core/src/routes/comments/service.ts
+++ b/apps/core/src/routes/comments/service.ts
@@ -53,6 +53,7 @@ export async function getReactions({
 }: GetReactionQuery) {
   const filter: FilterQuery<AnyObject> = {
     teacher: teacherId,
+    active: true
   };
 
   if (subjectId) {


### PR DESCRIPTION
## Descrição
Este PR inclui a chave `active` na query de comentários de professores. Isso abre a possibilidade de usarmos essa chave para desativar comentários caso seja necessário