### PR TITLE
Feature/log enrollments for wpp

### DIFF
--- a/apps/core/src/routes/entities/enrollments/index.ts
+++ b/apps/core/src/routes/entities/enrollments/index.ts
@@ -1,11 +1,23 @@
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi';
-import { findComment, findOne, listByRa } from './service.js';
+import {
+  findComment,
+  findOne,
+  listByRa,
+  listWithComponents,
+} from './service.js';
 import { listUserEnrollments } from '@/schemas/entities/enrollments.js';
+import { currentQuad } from '@next/common';
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
   app.get('/', { schema: listUserEnrollments }, async ({ user }) => {
     const userEnrollments = await listByRa(user.ra);
     return userEnrollments;
+  });
+
+  app.get('/wpp', async ({ user }) => {
+    const season = currentQuad();
+    const wppEnrollments = await listWithComponents(user.ra, season);
+    return wppEnrollments;
   });
 
   app.get('/:enrollmentId', async (request, reply) => {

--- a/apps/core/src/routes/entities/enrollments/service.ts
+++ b/apps/core/src/routes/entities/enrollments/service.ts
@@ -1,8 +1,10 @@
 import { CommentModel } from '@/models/Comment.js';
+import { ComponentModel } from '@/models/Component.js';
 import { EnrollmentModel } from '@/models/Enrollment.js';
 import type { SubjectDocument } from '@/models/Subject.js';
 import type { TeacherDocument } from '@/models/Teacher.js';
 import type { EnrollmentsList } from '@/schemas/entities/enrollments.js';
+import type { currentQuad } from '@next/common';
 
 type PopulatedFields = {
   pratica: TeacherDocument;
@@ -35,4 +37,59 @@ export async function findOne(id: string, ra: number) {
 export async function findComment(enrollmentId: string) {
   const comment = await CommentModel.find({ enrollment: enrollmentId }).lean();
   return comment;
+}
+
+export async function listWithComponents(
+  ra: number,
+  season: ReturnType<typeof currentQuad>,
+) {
+  const enrollments = await EnrollmentModel.find({
+    ra,
+    season: '2025:2',
+  }).lean();
+  const matchingComponents = await ComponentModel.find({
+    season: '2025:2',
+    uf_cod_turma: {
+      $in: enrollments.map((enrollment) => enrollment.uf_cod_turma),
+    },
+  })
+    .populate<{
+      teoria: TeacherDocument;
+      pratica: TeacherDocument;
+    }>(['teoria', 'pratica'])
+    .lean();
+
+  // final payload
+  /**
+   * season,
+   * groupURL,
+   * codigo,
+   * pratica/teoria,
+   * campus,
+   * turma,
+   * turno,
+   * disciplina,
+   */
+
+  const payload = enrollments.map((enrollment) => {
+    const component = matchingComponents.find(
+      (component) =>
+        component.disciplina_id === enrollment.disciplina_id &&
+        component.uf_cod_turma === enrollment.uf_cod_turma,
+    );
+
+    return {
+      season,
+      groupURL: component?.groupURL,
+      codigo: enrollment.disciplina_id,
+      campus: enrollment.campus,
+      turma: enrollment.turma,
+      turno: enrollment.turno,
+      subject: enrollment.disciplina,
+      teoria: component?.teoria?.name,
+      pratica: component?.pratica?.name,
+    };
+  });
+
+  return payload;
 }

--- a/apps/core/src/routes/entities/enrollments/service.ts
+++ b/apps/core/src/routes/entities/enrollments/service.ts
@@ -46,19 +46,21 @@ export async function listWithComponents(
   const enrollments = await EnrollmentModel.find({
     ra,
     season: '2025:2',
-  }).lean();
-  const matchingComponents = await ComponentModel.find({
-    season: '2025:2',
-    uf_cod_turma: {
-      $in: enrollments.map((enrollment) => enrollment.uf_cod_turma),
-    },
   })
     .populate<{
-      teoria: TeacherDocument;
       pratica: TeacherDocument;
-    }>(['teoria', 'pratica'])
+      teoria: TeacherDocument;
+    }>(['pratica', 'teoria'])
     .lean();
-
+  const matchingComponents = await ComponentModel.find(
+    {
+      season: '2025:2',
+      uf_cod_turma: {
+        $in: enrollments.map((enrollment) => enrollment.uf_cod_turma),
+      },
+    },
+    { _id: 0, groupURL: 1, disciplina_id: 1, uf_cod_turma: 1 },
+  ).lean();
   // final payload
   /**
    * season,
@@ -81,13 +83,13 @@ export async function listWithComponents(
     return {
       season,
       groupURL: component?.groupURL,
-      codigo: enrollment.disciplina_id,
+      codigo: enrollment.disciplina,
       campus: enrollment.campus,
       turma: enrollment.turma,
       turno: enrollment.turno,
       subject: enrollment.disciplina,
-      teoria: component?.teoria?.name,
-      pratica: component?.pratica?.name,
+      teoria: enrollment.pratica?.name ?? 'N/A',
+      pratica: enrollment.teoria?.name ?? 'N/A',
     };
   });
 


### PR DESCRIPTION
This pull request introduces a new API endpoint and supporting logic to fetch enrollment data with associated components for a specific season. The changes include updates to the routing file and service file to implement this functionality.

### New API Endpoint for Enrollment Data with Components:

* **`apps/core/src/routes/entities/enrollments/index.ts`**: Added a new `/wpp` endpoint that retrieves enrollment data for the current season using the `listWithComponents` function.
* **`apps/core/src/routes/entities/enrollments/service.ts`**: Implemented the `listWithComponents` function to fetch enrollments and their matching components based on the season and `uf_cod_turma`. The function returns a structured payload containing detailed information about enrollments and components.

### Supporting Changes:

* **`apps/core/src/routes/entities/enrollments/index.ts`**: Imported the `currentQuad` utility to determine the current season.
* **`apps/core/src/routes/entities/enrollments/service.ts`**: Added `ComponentModel` import and updated type definitions to support the new functionality.