### PR TITLE
fix: error info not visible in logs

### DIFF
--- a/apps/core/src/app.ts
+++ b/apps/core/src/app.ts
@@ -92,7 +92,11 @@ export async function buildApp(
     if (error) {
       app.log.error(
         {
-          error,
+          error: {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+          },
           request: {
             method: request.method,
             url: request.url,

--- a/apps/core/src/app.ts
+++ b/apps/core/src/app.ts
@@ -92,11 +92,7 @@ export async function buildApp(
     if (error) {
       app.log.error(
         {
-          error: {
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-          },
+          error,
           request: {
             method: request.method,
             url: request.url,

--- a/apps/core/src/utils/logger.ts
+++ b/apps/core/src/utils/logger.ts
@@ -34,6 +34,9 @@ const axiomOptions = {
 const loggerSetup = {
   dev: {
     timestamp: pino.stdTimeFunctions.isoTime,
+    serializers: {
+      error: pino.stdSerializers.err,
+    },
     transport: {
       targets: [
         {

--- a/apps/core/src/utils/logger.ts
+++ b/apps/core/src/utils/logger.ts
@@ -61,6 +61,9 @@ const loggerSetup = {
   // Minimal config for production
   prod: {
     timestamp: pino.stdTimeFunctions.isoTime,
+    serializers: {
+      error: pino.stdSerializers.err,
+    },
     transport: {
       targets: [
         {


### PR DESCRIPTION
Os erros genericos do compilador do node não estão aparecendo corretamente nos logs.

Caso de estudo:

Forcei um simples ReferenceError no endpoint backoffice/jobs/failed para ilustrar a problematica:
<img width="407" height="167" alt="image" src="https://github.com/user-attachments/assets/6c13057f-77a4-43e5-a19b-831a7c8cbf1d" />

Antes (repare o objeto vazio no campo `error`):
<img width="659" height="211" alt="image" src="https://github.com/user-attachments/assets/0275031f-3784-45a8-8972-e7f35c706144" />

Depois:
<img width="782" height="196" alt="image" src="https://github.com/user-attachments/assets/7d930d46-aef1-4a8b-9539-1f5fe991b940" />

