### PR TITLE
wip: add docker compose to simulate gh actions container

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,61 @@ Utilitários que o monorepo possui ja configurado
 - [Biome](https://biomejs.dev/) Lint & format
 - [Node.js](https://nodejs.org/api/test.html) para realização de testes unitários
 - [Renovate](https://docs.renovatebot.com/) para manter a saúde das dependências do projeto
+
+
+🔐 Gerenciamento Seguro de .env.prod com git-secret via Docker
+
+Este projeto utiliza o [git-secret](https://sobolevn.me/git-secret/?utm_source=chatgpt.com)
+ para proteger o arquivo .env.prod e garantir que apenas membros autorizados da equipe tenham acesso a informações sensíveis.
+
+📦 Atualização Segura do .env.prod
+
+Para atualizar ou criptografar o arquivo .env.prod, utilizamos um container Docker com git-secret configurado. Isso evita a necessidade de instalar GPG ou git-secret na sua máquina local.
+
+1. Build da imagem Docker
+docker compose up -d
+
+2. Entrar no container
+docker run -it --rm -v $(pwd):/home/devuser/app git-secret-env
+
+
+🔓 Como acessar o .env.prod
+
+O arquivo .env.prod.secret pode ser descriptografado por qualquer pessoa que:
+
+Tenha uma chave GPG adicionada via git secret tell.
+
+Tenha a senha da chave privada correspondente.
+
+❗ Solicitação de acesso
+
+Se você é um novo contribuidor:
+
+Gere uma chave GPG (ou use uma existente).
+
+Envie sua chave pública GPG para um membro autorizado do projeto.
+
+Um membro irá adicioná-lo com:
+
+git secret tell email@seu-dominio.com
+
+
+Após isso, você poderá rodar:
+
+git secret reveal
+
+
+e será solicitado a digitar sua senha da chave GPG privada.
+
+✉️ Solicite acesso entrando em contato com um dos mantenedores do projeto.
+
+🛠 Recomendações
+
+Nunca commit o arquivo .env.prod diretamente.
+
+Sempre use git secret hide após modificações no .env.prod.
+
+Só compartilhe sua chave GPG pública, nunca a privada.
+
+Garanta que sua chave GPG tenha uma senha forte e segura.
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,33 @@
+version: "3.8"
+
 services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: next-app
+    depends_on:
+      - next-db
+      - next-redis
+      - localstack
+    ports:
+      - "3000:3000" # Altere se sua app escutar em outra porta
+    environment:
+      NODE_ENV: development
+      MONGO_URI: mongodb://next-db:27017/your-db-name
+      REDIS_HOST: next-redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: qj6wGxXINcQyWXdN
+      AWS_ACCESS_KEY_ID: AWS_ACCESS_KEY_ID_LOCALSTACK
+      AWS_SECRET_ACCESS_KEY: AWS_SECRET_ACCESS_KEY_LOCALSTACK
+      AWS_REGION: us-east-1
+      # Adicione aqui outras variáveis necessárias
+
+    volumes:
+      - .:/usr/src/app
+    working_dir: /usr/src/app
+    command: npm run dev # ou 'yarn dev' ou outro start script
+
   next-db:
     image: mongo:latest
     container_name: next-db


### PR DESCRIPTION
📦 Descrição da PR

Esta PR adiciona suporte ao uso do git-secret via Docker, com o objetivo de facilitar o setup do ambiente local para novos mantenedores e o gerenciamento seguro do arquivo .env.prod.

✅ O que foi feito:


Atualizado o docker-compose.yml para incluir um container isolado da aplicação (app) com acesso a:

Git secrets 

Documentação (README.md) explicando como:

Inicializar o git-secret

Adicionar contribuidores via git secret tell

Proteger e atualizar o .env.prod de forma segura

Descriptografar o ambiente com a chave GPG correta e senha

🎯 Objetivo

Padronizar e isolar o processo de gerenciamento das variáveis de produção sensíveis através de um ambiente Docker, eliminando a necessidade de instalar ferramentas localmente. Isso também evita o vazamento acidental de .env.prod, garantindo que apenas membros autorizados, com suas chaves GPG cadastradas, possam acessar ou modificar esse conteúdo.

👥 Para contribuidores

Para descriptografar o .env.prod, envie sua chave GPG pública para um dos mantenedores.

Após ser adicionado via git secret tell, você poderá usar o container para executar git secret reveal de forma segura.