### PR TITLE
feat: send-email endpoint

### DIFF
--- a/apps/core/src/routes/backoffice/send-email.ts
+++ b/apps/core/src/routes/backoffice/send-email.ts
@@ -1,0 +1,111 @@
+import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi';
+import { z } from 'zod';
+import { sesClient } from '@/lib/aws.service.js';
+import { SendEmailCommand, type SendEmailCommandInput } from '@aws-sdk/client-ses';
+
+// Endpoint básico para envio em massa que aceita um assunto, corpo HTML (ex: renderizado pelo Vue Email),
+// e uma lista de destinatários. Agrupa os destinatários em grupos BCC para eficiência.
+
+const MAX_RECIPIENTS_PER_MESSAGE = 50; // Limite emails do SES por chamada (Revisar esse limite)
+
+// Também é possível enviar em paralelo em batches (concorrência) seguindo o limite do SES (Checar a quantidade se fizer isso)
+// Assim, as chamadas seriam feitas em paralelo, e o tempo seria menor.
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
+  app.post(
+    '/send-email',
+    {
+      schema: {
+        body: z.object({
+          subject: z.string().min(1),
+          html: z.string().min(1),
+          recipients: z.array(z.string().email()).min(1),
+          from: z.string().email().optional(),
+          replyTo: z.array(z.string().email()).optional(),
+          batchSize: z.number().int().min(1).max(MAX_RECIPIENTS_PER_MESSAGE).optional(),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const {
+        subject,
+        html,
+        recipients,
+        from,
+        replyTo,
+        batchSize = MAX_RECIPIENTS_PER_MESSAGE,
+      } = request.body;
+
+      // Remove duplicados da lista de destinatários para evitar envios duplos utilizando o set
+      const uniqueRecipients = Array.from(new Set(recipients));
+
+      const fromIdentity = from ?? 'contato@ufabcnext.com'; // Email deve estar verificado no SES
+
+      // Agrupa os destinatários em lotes respeitando o limite do SES
+      const batches = chunk(
+        uniqueRecipients,
+        Math.min(batchSize, MAX_RECIPIENTS_PER_MESSAGE),
+      );
+
+      const results: Array<
+        | { ok: true; messageId?: string; batch: number }
+        | { ok: false; error: string; batch: number }
+      > = [];
+
+      for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+        const bcc = batches[batchIndex];
+
+        const input: SendEmailCommandInput = {
+          Source: `UFABC next <${fromIdentity}>`,
+          Destination: {
+            // Usando BCC para manter os emails privados entre destinatários
+            BccAddresses: bcc,
+          },
+          ReplyToAddresses: replyTo,
+          Message: {
+            Subject: { Data: subject, Charset: 'UTF-8' },
+            Body: {
+              Html: { Data: html, Charset: 'UTF-8' },
+            },
+          },
+        };
+
+        try {
+          const cmd = new SendEmailCommand(input);
+          const res = await sesClient.send(cmd);
+          results[batchIndex] = { ok: true, messageId: res.MessageId, batch: batchIndex };
+          app.log.info(
+            { batch: batchIndex, recipients: bcc.length, messageId: res.MessageId },
+            'Lote de email enviado',
+          );
+        } catch (err: any) {
+          results[batchIndex] = { ok: false, error: err?.message ?? 'unknown', batch: batchIndex };
+          app.log.error({ err, batch: batchIndex }, 'Falha no envio do lote de email');
+        }
+      }
+
+      const ok = results.filter((r) => r?.ok).length;
+      const failed = results.length - ok;
+
+      return reply.send({
+        totalRecipients: uniqueRecipients.length,
+        batches: batches.length,
+        batchSize: Math.min(batchSize, MAX_RECIPIENTS_PER_MESSAGE),
+        sentBatches: ok,
+        failedBatches: failed,
+        // Falhas são resumidas por lote; você pode tentar novamente apenas os índices de lote que falharam
+        failures: results
+          .map((r, i) => ({ ...r, recipients: batches[i]?.length }))
+          .filter((r) => !(r as any).ok),
+      });
+    },
+  );
+};
+
+export default plugin;


### PR DESCRIPTION
# 📧 Implementação do Endpoint de Envio de Emails em Massa

## Objetivo

Implementar um endpoint para envio de emails em massa utilizando AWS SES, permitindo o envio de conteúdo HTML personalizado (ex: Vue Email) para múltiplos destinatários de forma eficiente.

## 🛠️ Implementação

- **Endpoint**: `POST /backoffice/send-email`

### 📋 Schema

```typescript
{
  subject: string,           // Assunto
  html: string,             // Corpo HTML do email
  recipients: string[],     // Lista de emails
  from?: string,            // Email remetente (padrão: contato@ufabcnext.com)
  batchSize?: number        // Tamanho do lote (opcional, padrão: 50)
}
```

### Funcionamento

#### **Batching BCC**

- Agrupa destinatários em lotes de até **XX emails** (revisar esse limite)
- Utiliza **BCC** para manter privacidade entre destinatários
- Remove automaticamente emails duplicados

#### **Envio Sequencial**

- Processamento de um lote por vez para evitar throttling do SES

## Revisões e Ideias

A implementação atual utiliza envio sequencial, mas é possível implementar uma concorrência, que traria maior throughput, menor tempo total. Para isso temos que revisar qual os valores de limite reais do SES (Email Max e TPS)

### 📊 **Limites do AWS SES**

- **Por mensagem**: Máximo XX destinatários (Talvez 50)
- **TPS**: Varia por conta (Revisar qual o valor desse TPS e se seguir com ideia de concorrência)

### 🔄 **Uso Atual**

- **Envio sequencial**: Um lote por vez
- **Sem concorrência**
- **Agrupamento por BCC**: Máxima eficiência por chamada para o AWS SES
