### PR TITLE
fix: cap backend node heap in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Certifique-se de que o AWS CLI original esteja instalado em seu sistema.
 # De `start` no projeto
 pnpm dev
 
+## Nota de runtime em produção
+
+O processo principal do backend sobe com `--max-old-space-size=1536` no script `apps/core:start`.
+Isso cria um teto de heap para o Node em produção e ajuda a evitar que um único processo consuma toda a memória disponível da instância.
+
 
 ## O que temos no repo?
 

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -11,8 +11,8 @@
     "dev": "tsx watch --env-file=.env.dev src/server.ts",
     "build": "rimraf dist && tspc",
     "tsc": "tsc",
-    "start": "node --env-file=.env.prod dist/server.js",
-    "start:local": "pnpm build && node --env-file=.env.prod dist/server.js",
+    "start": "node --max-old-space-size=1536 --env-file=.env.prod dist/server.js",
+    "start:local": "pnpm build && node --max-old-space-size=1536 --env-file=.env.prod dist/server.js",
     "test": "vitest",
     "test:watch": "vitest watch"
   },


### PR DESCRIPTION
## Motivação
O backend em produção precisava de um guardrail rápido e de baixo risco porque o modo de falha apontava para pressão de recursos, e não para um bug já confirmado na lógica de negócio. A ideia foi reduzir a chance de um único processo Node consumir memória demais na EC2 e derrubar o serviço inteiro.

## O que mudou
- limita a heap do runtime Node em produção para 1536 MB
- documenta esse guardrail de runtime no README do backend

## Análise
Antes dessa mudança, o processo do backend subia sem um teto explícito de heap do V8. Em uma EC2 com recursos limitados, isso significa que o processo pode continuar crescendo até competir de forma agressiva com o sistema operacional, Docker, nginx e alocações nativas de memória. Ao adicionar `--max-old-space-size=1536`, o serviço passa a ter um limite previsível para consumo de heap JavaScript, preservando margem para o restante da máquina.

Essa mudança é propositalmente um safeguard operacional, não uma afirmação de que a causa raiz já foi corrigida. Se existir um vazamento real de memória, esse ajuste não vai eliminá-lo, mas vai tornar a falha mais controlada e reduzir o blast radius de instabilidade da máquina inteira para pressão no processo.

## Tradeoffs
- em caso de crescimento sustentado de memória, o processo pode falhar antes em vez de consumir a instância inteira
- a mudança não resolve sozinha consumo de memória nativa nem pressão de disco
- o valor foi escolhido de forma conservadora para preservar folga na máquina

## Validação
- `pnpm build`