### PR TITLE
feat: add redirect targets for oauth flow to support localhost

### DIFF
--- a/apps/core/src/constants.ts
+++ b/apps/core/src/constants.ts
@@ -32,6 +32,7 @@ export const JOB_NAMES = {
 } as const;
 
 export const REQUESTERS = ['ufabc-next', 'ufabc-cronos'] as const;
+export const REDIRECT_TARGETS = ['web', 'web-local'] as const;
 
 export const HTTP_REDIS_KEY_PREFIX = 'http';
 export const MAX_LOG_SIZE = 600 * 1024;

--- a/apps/core/src/plugins/external/oauth2.ts
+++ b/apps/core/src/plugins/external/oauth2.ts
@@ -64,10 +64,11 @@ export default fp(
             throw new Error('Invalid redirect target');
         }
 
-        if (redirectTarget === 'web-local' && requesterKey !== 'ufabc-next')
-          throw new Error(
-            'Redirect target web-local is only allowed for ufabc-next'
-          );
+        if (redirectTarget === 'web-local' && requesterKey !== 'ufabc-next') {
+            throw new Error(
+              'Redirect target web-local is only allowed for ufabc-next'
+            );
+        }
 
         return true;
       },

--- a/apps/core/src/plugins/external/oauth2.ts
+++ b/apps/core/src/plugins/external/oauth2.ts
@@ -60,8 +60,9 @@ export default fp(
         if (!REQUESTERS.includes(requesterKey))
           throw new Error('Invalid requester key');
 
-        if (redirectTarget && !REDIRECT_TARGETS.includes(redirectTarget))
-          throw new Error('Invalid redirect target');
+        if (redirectTarget && !REDIRECT_TARGETS.includes(redirectTarget)) {
+            throw new Error('Invalid redirect target');
+        }
 
         if (redirectTarget === 'web-local' && requesterKey !== 'ufabc-next')
           throw new Error(

--- a/apps/core/src/plugins/external/oauth2.ts
+++ b/apps/core/src/plugins/external/oauth2.ts
@@ -3,7 +3,7 @@ import { fastifyPlugin as fp } from 'fastify-plugin';
 
 import type { Auth } from '@/schemas/auth.js';
 
-import { REQUESTERS } from '@/constants.js';
+import { REDIRECT_TARGETS, REQUESTERS } from '@/constants.js';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -17,6 +17,13 @@ declare module 'fastify' {
 export type statePayloadType = {
   userId: string;
   requesterKey: 'ufabc-next' | 'ufabc-cronos';
+  redirectTarget?: 'web' | 'web-local';
+};
+
+type GoogleAuthorizationQuery = {
+  userId?: string;
+  requesterKey?: 'ufabc-next' | 'ufabc-cronos';
+  redirectTarget?: 'web' | 'web-local';
 };
 
 export default fp(
@@ -35,23 +42,31 @@ export default fp(
       callbackUri: (req) =>
         `${app.config.PROTOCOL}://${req.host}/login/google/callback`,
       generateStateFunction: (request) => {
-        // @ts-ignore
+        const query = request.query as GoogleAuthorizationQuery;
         const payload = {
-          userId: (request.query as any).userId ?? null,
-          requesterKey: (request.query as any).requesterKey ?? null,
+          userId: query.userId ?? '',
+          requesterKey: query.requesterKey ?? null,
+          redirectTarget: query.redirectTarget,
         };
 
         return Buffer.from(JSON.stringify(payload)).toString('base64url');
       },
       checkStateFunction: (request) => {
-        const { requesterKey } = JSON.parse(
-          Buffer.from((request.query as any).state, 'base64url').toString(
-            'utf8'
-          )
+
+        const { requesterKey, redirectTarget } = JSON.parse(
+          Buffer.from((request.query as any).state, 'base64url').toString('utf8')
         ) as statePayloadType;
 
         if (!REQUESTERS.includes(requesterKey))
           throw new Error('Invalid requester key');
+
+        if (redirectTarget && !REDIRECT_TARGETS.includes(redirectTarget))
+          throw new Error('Invalid redirect target');
+
+        if (redirectTarget === 'web-local' && requesterKey !== 'ufabc-next')
+          throw new Error(
+            'Redirect target web-local is only allowed for ufabc-next'
+          );
 
         return true;
       },

--- a/apps/core/src/routes/login/index.ts
+++ b/apps/core/src/routes/login/index.ts
@@ -11,6 +11,12 @@ import {
   type LegacyGoogleUser,
 } from '@/schemas/login.js';
 
+type RequestersUrls = {
+  next: string;
+  nextLocal: string;
+  cronos: string;
+};
+
 export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
   app.get(
     '/google',
@@ -64,28 +70,19 @@ export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           permissions: user.permissions,
         });
 
-        let baseUrl =
-          requesterKey === 'ufabc-next' && redirectTarget === 'web-local'
-            ? 'http://localhost:3000'
-            : app.config.WEB_URL;
-        let page = 'login';
-        let params: { token?: string; advice?: boolean } = { token: jwtToken };
+        const DEFAULT_REQUESTERS_URLS: RequestersUrls = {
+          next: app.config.WEB_URL,
+          nextLocal: 'http://localhost:3000',
+          cronos: app.config.CRONOS_URL,
+        };
 
-        if (requesterKey === 'ufabc-cronos') {
-          if (!user.confirmed) {
-            page = 'signup';
-            //se o user tenta entrar no cronos mas nao tem conta no next, redireciona para o front do next com um aviso
-            params = { advice: true };
-          } else {
-            baseUrl = app.config.CRONOS_URL;
-            page = '/';
-          }
-        }
-
-        const redirectURL = new URL(page, baseUrl);
-
-        for (const [key, value] of Object.entries(params))
-          redirectURL.searchParams.append(key, String(value));
+        const redirectURL = buildRedirectURL({
+          requesterKey,
+          redirectTarget,
+          jwtToken,
+          isUserConfirmed: user.confirmed,
+          requestersUrls: DEFAULT_REQUESTERS_URLS,
+        });
 
         return reply.redirect(redirectURL.href);
       } catch (error: any) {
@@ -210,6 +207,74 @@ async function createOrLogin(
   } catch (error) {
     logger.error({ error, oauthUser }, 'Error in createOrLogin');
     throw error;
+  }
+}
+
+function buildRedirectURL({
+  requesterKey,
+  redirectTarget,
+  jwtToken,
+  isUserConfirmed,
+  requestersUrls,
+}: {
+  requesterKey: 'ufabc-next' | 'ufabc-cronos';
+    redirectTarget?: 'web' | 'web-local';
+    jwtToken: string;
+    isUserConfirmed: boolean;
+    requestersUrls: RequestersUrls;
+  }) {
+  const { baseUrl, page, params } = requesterKey === 'ufabc-cronos'
+    ? getUfabcCronosUrlDefaults({ jwtToken, isUserConfirmed, requestersUrls })
+    : getUfabcNextUrlDefaults({ jwtToken, redirectTarget, requestersUrls });
+  
+  
+  const redirectURL = new URL(page, baseUrl);
+
+  for (const [key, value] of Object.entries(params))
+    redirectURL.searchParams.append(key, String(value));
+
+  return redirectURL;
+}
+
+function getUfabcCronosUrlDefaults({
+  jwtToken,
+  isUserConfirmed,
+  requestersUrls,
+}: {
+  jwtToken: string;
+  isUserConfirmed: boolean;
+  requestersUrls: RequestersUrls;
+  }) {
+  if (isUserConfirmed) { 
+    return {
+      baseUrl: requestersUrls.cronos,
+      page: '/',
+      params: { token: jwtToken },
+    }
+  }
+  
+  // se o user tenta entrar no cronos mas nao tem conta no next, 
+  // redireciona para o front do next com um aviso
+  return {
+    baseUrl: requestersUrls.next,
+    page: 'signup',
+    params: { advice: true },
+  }
+}
+
+function getUfabcNextUrlDefaults({
+  jwtToken,
+  redirectTarget,
+  requestersUrls,
+}: {
+  jwtToken: string;
+  redirectTarget?: 'web' | 'web-local';
+  requestersUrls: RequestersUrls;
+  }) { 
+  return {
+    baseUrl: redirectTarget === 'web-local' ? requestersUrls.nextLocal : requestersUrls.next,
+    page: 'login',
+    params: { token: jwtToken },
   }
 }
 

--- a/apps/core/src/routes/login/index.ts
+++ b/apps/core/src/routes/login/index.ts
@@ -12,31 +12,34 @@ import {
 } from '@/schemas/login.js';
 
 export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
-  app.get('/google', async function (request, reply) {
-    const validatedURI = await this.google.generateAuthorizationUri(
-      request,
-      reply
-    );
-    const redirectURL = new URL(validatedURI);
-    redirectURL.searchParams.append('prompt', 'select_account');
+  app.get(
+    '/google',
+    async function (request, reply) {
+      const validatedURI = await this.google.generateAuthorizationUri(
+        request,
+        reply
+      );
+      const redirectURL = new URL(validatedURI);
+      redirectURL.searchParams.append('prompt', 'select_account');
 
-    app.log.debug(
-      {
-        url: redirectURL.hostname,
-        query: redirectURL.search.split('&'),
-        port: request.hostname,
-      },
-      '[OAUTH] start'
-    );
-    return reply.redirect(redirectURL.href);
-  });
+      app.log.debug(
+        {
+          url: redirectURL.hostname,
+          query: redirectURL.search.split('&'),
+          port: request.hostname,
+        },
+        '[OAUTH] start'
+      );
+      return reply.redirect(redirectURL.href);
+    }
+  );
 
   app.get(
     '/google/callback',
     { schema: googleCallbackSchema },
     async function (request, reply) {
       try {
-        const { requesterKey, userId } = JSON.parse(
+        const { requesterKey, userId, redirectTarget } = JSON.parse(
           Buffer.from(request.query.state, 'base64url').toString()
         ) as statePayloadType;
         const { token } =
@@ -61,7 +64,10 @@ export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           permissions: user.permissions,
         });
 
-        let baseUrl = app.config.WEB_URL;
+        let baseUrl =
+          requesterKey === 'ufabc-next' && redirectTarget === 'web-local'
+            ? 'http://localhost:3000'
+            : app.config.WEB_URL;
         let page = 'login';
         let params: { token?: string; advice?: boolean } = { token: jwtToken };
 

--- a/apps/core/src/routes/login/index.ts
+++ b/apps/core/src/routes/login/index.ts
@@ -11,7 +11,7 @@ import {
   type LegacyGoogleUser,
 } from '@/schemas/login.js';
 
-type RequestersUrls = {
+type RequesterUrls = {
   next: string;
   nextLocal: string;
   cronos: string;
@@ -70,7 +70,7 @@ export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           permissions: user.permissions,
         });
 
-        const DEFAULT_REQUESTERS_URLS: RequestersUrls = {
+        const requesterUrls: RequesterUrls = {
           next: app.config.WEB_URL,
           nextLocal: 'http://localhost:3000',
           cronos: app.config.CRONOS_URL,
@@ -81,7 +81,7 @@ export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           redirectTarget,
           jwtToken,
           isUserConfirmed: user.confirmed,
-          requestersUrls: DEFAULT_REQUESTERS_URLS,
+          requesterUrls,
         });
 
         return reply.redirect(redirectURL.href);
@@ -215,67 +215,71 @@ function buildRedirectURL({
   redirectTarget,
   jwtToken,
   isUserConfirmed,
-  requestersUrls,
+  requesterUrls,
 }: {
   requesterKey: 'ufabc-next' | 'ufabc-cronos';
-    redirectTarget?: 'web' | 'web-local';
-    jwtToken: string;
-    isUserConfirmed: boolean;
-    requestersUrls: RequestersUrls;
-  }) {
-  const { baseUrl, page, params } = requesterKey === 'ufabc-cronos'
-    ? getUfabcCronosUrlDefaults({ jwtToken, isUserConfirmed, requestersUrls })
-    : getUfabcNextUrlDefaults({ jwtToken, redirectTarget, requestersUrls });
-  
-  
-  const redirectURL = new URL(page, baseUrl);
+  redirectTarget?: 'web' | 'web-local';
+  jwtToken: string;
+  isUserConfirmed: boolean;
+  requesterUrls: RequesterUrls;
+}) {
+  const { baseUrl, path, params } =
+    requesterKey === 'ufabc-cronos'
+      ? getUfabcCronosRedirect({ jwtToken, isUserConfirmed, requesterUrls })
+      : getUfabcNextRedirect({ jwtToken, redirectTarget, requesterUrls });
 
-  for (const [key, value] of Object.entries(params))
-    redirectURL.searchParams.append(key, String(value));
+  const redirectURL = new URL(path, baseUrl);
+
+  for (const [key, value] of Object.entries(params)) {
+    redirectURL.searchParams.set(key, value);
+  }
 
   return redirectURL;
 }
 
-function getUfabcCronosUrlDefaults({
+function getUfabcCronosRedirect({
   jwtToken,
   isUserConfirmed,
-  requestersUrls,
+  requesterUrls,
 }: {
   jwtToken: string;
   isUserConfirmed: boolean;
-  requestersUrls: RequestersUrls;
-  }) {
-  if (isUserConfirmed) { 
+  requesterUrls: RequesterUrls;
+}) {
+  if (isUserConfirmed) {
     return {
-      baseUrl: requestersUrls.cronos,
-      page: '/',
+      baseUrl: requesterUrls.cronos,
+      path: '/',
       params: { token: jwtToken },
-    }
+    };
   }
-  
-  // se o user tenta entrar no cronos mas nao tem conta no next, 
-  // redireciona para o front do next com um aviso
+
+  // If a user logs in through Cronos without a UFABC Next account,
+  // redirect to UFABC Next signup with an advisory message.
   return {
-    baseUrl: requestersUrls.next,
-    page: 'signup',
-    params: { advice: true },
-  }
+    baseUrl: requesterUrls.next,
+    path: '/signup',
+    params: { advice: 'true' },
+  };
 }
 
-function getUfabcNextUrlDefaults({
+function getUfabcNextRedirect({
   jwtToken,
   redirectTarget,
-  requestersUrls,
+  requesterUrls,
 }: {
   jwtToken: string;
   redirectTarget?: 'web' | 'web-local';
-  requestersUrls: RequestersUrls;
-  }) { 
+  requesterUrls: RequesterUrls;
+}) {
   return {
-    baseUrl: redirectTarget === 'web-local' ? requestersUrls.nextLocal : requestersUrls.next,
-    page: 'login',
+    baseUrl:
+      redirectTarget === 'web-local'
+        ? requesterUrls.nextLocal
+        : requesterUrls.next,
+    path: '/login',
     params: { token: jwtToken },
-  }
+  };
 }
 
 export default plugin;


### PR DESCRIPTION
## Descrição

Adiciona suporte para definir o destino do redirect do OAuth Google no backend, permitindo autenticação com prod mesmo em ambiente local

### O que mudou

- Rota `/login/google` passou a aceitar query param opcional `redirectTarget`.

**Comportamento de redirect no callback:**
  - padrão (sem `redirectTarget` ou `redirectTarget=web`): mantém redirect atual para `ufabcnext.com/login?token=...`.
  - url `requesterKey=ufabc-next&redirectTarget=web-local`: redireciona para `http://localhost:3000/login?token=...`.
  - fluxo `ufabc-cronos` mantido inalterado

Totalmente ligado com: https://github.com/ufabc-next/ufabc-next-web/pull/475/files