### PR TITLE
feat: add call to metadata discipline

### DIFF
--- a/apps/core/src/connectors/ai-proxy.ts
+++ b/apps/core/src/connectors/ai-proxy.ts
@@ -56,8 +56,8 @@ export class AIProxyConnector extends BaseRequester {
       componentData?.metadata?.component_data?.teachers?.[0]?.name ?? ''
     );
 
-    const cronogramaArr = Array.isArray(componentData?.metadata?.component_data?.syllabus)
-      ? componentData.metadata.component_data.syllabus
+    const cronogramaArr = Array.isArray(componentData?.cronograma)
+      ? componentData.cronograma
       : [];
     const cronograma_str = cronogramaArr
       .map((a: any) => `- ${a.data}: ${a.aula}`)

--- a/apps/core/src/connectors/ai-proxy.ts
+++ b/apps/core/src/connectors/ai-proxy.ts
@@ -1,3 +1,4 @@
+import { ComponentMetadataDocument } from '@/models/ComponentMetadata.js';
 import { BaseRequester } from './base-requester.js';
 
 type Files = {
@@ -31,4 +32,58 @@ export class AIProxyConnector extends BaseRequester {
     });
     return response;
   }
+
+
+  async requestNaturalResponse(componentData: ComponentMetadataDocument, userMessage: string) {
+    const headers = new Headers();
+
+    headers.set('x-service-id', 'whatsapp');
+   
+
+    const toTitleCase = (s?: string) =>
+      (s || '')
+        .toLowerCase()
+        .split(' ')
+        .filter(Boolean)
+        .map((w) => w[0].toUpperCase() + w.slice(1))
+        .join(' ');
+
+    const nome_disciplina = (
+      componentData?.metadata?.component_data?.name ?? ''
+    ).toString().toUpperCase();
+    const codigo_turma = componentData?.metadata?.component_code ?? '';
+    const professor = toTitleCase(
+      componentData?.metadata?.component_data?.teachers?.[0]?.name ?? ''
+    );
+
+    const cronogramaArr = Array.isArray(componentData?.metadata?.component_data?.syllabus)
+      ? componentData.metadata.component_data.syllabus
+      : [];
+    const cronograma_str = cronogramaArr
+      .map((a: any) => `- ${a.data}: ${a.aula}`)
+      .join('\n');
+
+    const ementa = componentData.planejamento?.ementa ?? 'Não informada.';
+    const metodologia = componentData.planejamento?.metodologia ?? 'Não informada.';
+    const avaliacao = componentData.planejamento?.avaliacao ?? 'Não informada.';
+
+    const horarios_list =
+      componentData?.metadata?.component_data?.timetable ?? [];
+    const horarios_str = horarios_list
+      .map((h: any) => `- ${h?.unparsed ?? ''}`)
+      .join('\n');
+
+    const basePrompt = `## Contexto:\nVocê é um assistente virtual especializado em responder dúvidas de alunos da Universidade Federal do ABC (UFABC).\nVocê está prestando suporte específico para a disciplina: **${nome_disciplina} (${codigo_turma})**.\nO professor responsável é: ${professor}.\n\nUse estritamente as informações oficiais do Plano de Ensino fornecidas abaixo para responder o aluno.\n\n## Informações Oficiais da Disciplina:\n\n### 1. Horários e Salas:\n${horarios_str}\n\n### 2. Ementa da Disciplina:\n${ementa}\n\n### 3. Metodologia de Ensino:\n${metodologia}\n\n### 4. Critério de Avaliação:\n${avaliacao}\n\n### 5. Cronograma de Aulas e Datas Importantes:\n${cronograma_str}\n\n## Sua tarefa:\n- Leia a mensagem recebida do aluno e identifique o que está sendo perguntado.\n- Responda de maneira assertiva, amigável e direta baseando-se estritamente nos dados acima.\n- Se a pergunta for sobre uma data específica (como uma prova ou feriado), consulte a seção de Cronograma.\n- Se a pergunta for sobre salas, horários ou formas de avaliação, consulte as seções respectivas.\n- Caso o aluno pergunte algo que NÃO está neste documento, informe educadamente que não possui essa informação e sugira que ele verifique no Moodle, SIGAA ou diretamente com o professor ${professor}.\n\n## Instruções de estilo:\n- Mantenha um tom acolhedor, jovem e prestativo (adequado para WhatsApp).\n- Use quebras de linha e emojis moderadamente para tornar a leitura escaneável no celular.\n- Responda sempre em Português.\n\n## Mensagem recebida do aluno:\n"${userMessage}"\n`;
+
+    const response = await this.request<unknown[]>('/', {
+      method: 'POST',
+      headers: headers,
+      body: {
+        promptData: basePrompt
+      },
+    });
+    return response;
+  }
+
+
 }

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -297,16 +297,17 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       const { season, componentId } = request.query;
 
       const component = await ComponentMetadataModel.findOne({
-        'metadata.component_code': componentId 
-      }).lean();
-
-      const { userMessage } = request.body as { userMessage: string };
-
-      const response = await aiConnector.requestNaturalResponse(component, userMessage);       
+        'metadata.component_code': componentId,
+        'metadata.component_data.season': season,
+      });
 
       if (!component) {
         return reply.notFound('Component not found');
       }
+
+      const { userMessage } = request.body as { userMessage: string };
+
+      const response = await aiConnector.requestNaturalResponse(component, userMessage);
 
       return reply.status(200).send({
         status: 'success',

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -14,6 +14,8 @@ import {
   PopulatedComponent,
 } from '@/schemas/v2/components.js';
 import { getComponentArchives } from '@/services/components-service.js';
+import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
+import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 
 const moodleConnector = new MoodleConnector();
 
@@ -265,6 +267,55 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       return reply.status(200).send(mappedComponents);
     },
   });
+
+
+
+  app.route({
+    method: 'POST',
+    url: '/components/metadata',
+    schema: {
+      querystring: z.object({
+        season: z.string().default('2026:2'),
+        componentId: z.string()
+      }),
+      body: z.object({
+        userMessage: z.string(),
+      }),
+      response: {
+        200: z.object({
+          status: z.string(),
+          data: z.any().optional(),
+        }),
+      },
+    },
+    handler: async (request, reply) => {
+
+      const baseUrl = process.env.NEXT_AGENT_URL;
+      //@ts-ignore
+      const aiConnector = new AIProxyConnector(baseUrl, 'whatsapp');
+
+      const { season, componentId } = request.query;
+
+      const component = await ComponentMetadataModel.findOne({
+        'metadata.component_code': componentId 
+      }).lean();
+
+      const { userMessage } = request.body as { userMessage: string };
+
+      const response = await aiConnector.requestNaturalResponse(component, userMessage);       
+
+      if (!component) {
+        return reply.notFound('Component not found');
+      }
+
+      return reply.status(200).send({
+        status: 'success',
+        data: response,
+      });
+    },
+  });
+
+
 };
 
 export default componentsController;

--- a/apps/core/src/models/ComponentMetadata.ts
+++ b/apps/core/src/models/ComponentMetadata.ts
@@ -1,0 +1,87 @@
+import { type InferSchemaType, Schema, model } from 'mongoose';
+
+const disciplinasMetadataSchema = new Schema(
+  {
+    planejamento: {
+      ementa: { type: String, required: true },
+      objetivos: { type: String, required: true },
+      metodologia: { type: String, required: true },
+      avaliacao: { type: String, required: true },
+    },
+    cronograma: [
+      {
+        aula: { type: String, required: true },
+        data: { type: String, required: true },
+        _id: false,
+      },
+    ],
+    metadata: {
+      source_file: { type: String, required: true },
+      processed_at: { type: String, required: true },
+      disciplina_id: { type: Number, required: true },
+      component_code: { type: String, required: true },
+      component_data: {
+        componentKey: { type: String, required: true },
+        subjectKey: { type: String, required: true },
+        name: { type: String, required: true },
+        credits: { type: Number, required: true },
+        ufComponentId: { type: Number, required: true },
+        alternateUfabcComponentId: { type: String, required: false },
+        ufComponentCode: { type: String, required: true },
+        campus: { type: String, required: true },
+        shift: { type: String, required: true },
+        vacancies: { type: Number, required: true },
+        componentClass: { type: String, required: true },
+        season: { type: String, required: true },
+        ufClassroomCode: { type: String, required: true },
+        tpi: {
+          theory: { type: Number, required: true },
+          practice: { type: Number, required: true },
+          individual: { type: Number, required: true },
+          _id: false,
+        },
+        timetable: [
+          {
+            dayOfTheWeek: { type: String, required: true },
+            startTime: { type: String, required: true },
+            endTime: { type: String, required: true },
+            periodicity: { type: String, required: false },
+            classroomCode: { type: String, required: true },
+            scheduleType: { type: String, required: true },
+            frequency: { type: String, required: true },
+            unparsed: { type: String, required: true },
+            _id: false,
+          },
+        ],
+        courses: [
+          {
+            category: { type: String, required: true },
+            UFCourseId: { type: Number, required: true },
+            _id: false,
+          },
+        ],
+        teachers: [
+          {
+            name: { type: String, required: true },
+            role: { type: String, required: true },
+            isSecondary: { type: Boolean, required: true },
+            _id: false,
+          },
+        ],
+        _id: false,
+      },
+      _id: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+
+disciplinasMetadataSchema.index({ 'metadata.component_code': 'asc' });
+
+export type Component = InferSchemaType<typeof disciplinasMetadataSchema>;
+export type ComponentMetadataDocument = ReturnType<(typeof ComponentMetadataModel)['hydrate']>;
+
+export const ComponentMetadataModel = model('disciplinas_metadata', disciplinasMetadataSchema, 'disciplinas_metadata');

--- a/apps/core/src/models/ComponentMetadata.ts
+++ b/apps/core/src/models/ComponentMetadata.ts
@@ -81,7 +81,7 @@ const disciplinasMetadataSchema = new Schema(
 
 disciplinasMetadataSchema.index({ 'metadata.component_code': 'asc' });
 
-export type Component = InferSchemaType<typeof disciplinasMetadataSchema>;
+export type ComponentMetadata = InferSchemaType<typeof disciplinasMetadataSchema>;
 export type ComponentMetadataDocument = ReturnType<(typeof ComponentMetadataModel)['hydrate']>;
 
 export const ComponentMetadataModel = model('disciplinas_metadata', disciplinasMetadataSchema, 'disciplinas_metadata');

--- a/apps/core/tests/integration/components/metadata.spec.ts
+++ b/apps/core/tests/integration/components/metadata.spec.ts
@@ -1,0 +1,116 @@
+import { startTestStack, type TestStack } from '@next/testing/containers';
+import { fastify, type FastifyInstance } from 'fastify';
+import { fastifyPlugin as fp } from 'fastify-plugin';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+import { buildApp } from '../../../src/app.js';
+import { AIProxyConnector } from '../../../src/connectors/ai-proxy.js';
+import { ComponentMetadataModel } from '../../../src/models/ComponentMetadata.js';
+
+describe('POST /v2/components/metadata', () => {
+  let stack: TestStack;
+  let app: FastifyInstance;
+  const componentCode = 'COMP-123';
+  const aiResponse = { answer: 'Mocked AI response' };
+
+  beforeAll(async () => {
+    if (!process.env.NEXT_AGENT_URL) {
+      process.env.NEXT_AGENT_URL = 'http://ai-proxy.test';
+    }
+
+    stack = await startTestStack();
+    app = fastify({ logger: false });
+
+    await app.register(fp(buildApp), {
+      config: { ...stack.config, NODE_ENV: 'test' },
+    });
+
+    await app.ready();
+  });
+
+  beforeEach(() => {
+    vi.spyOn(AIProxyConnector.prototype, 'requestNaturalResponse').mockResolvedValue(
+      aiResponse
+    );
+  });
+
+  afterAll(async () => {
+    await ComponentMetadataModel.deleteMany({
+      'metadata.component_code': componentCode,
+    });
+
+    await app.close();
+    await stack.stop();
+  });
+
+  it('should return 404 when component metadata is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/components/metadata',
+      query: { season: '2026:2', componentId: 'MISSING-001' },
+      payload: { userMessage: 'What is the schedule?' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = JSON.parse(res.body);
+    expect(body.message).toBe('Component not found');
+  });
+
+  it('should call AI proxy and return response for a known component', async () => {
+    await ComponentMetadataModel.create({
+      planejamento: {
+        ementa: 'Test syllabus',
+        objetivos: 'Test objectives',
+        metodologia: 'Test method',
+        avaliacao: 'Test evaluation',
+      },
+      cronograma: [],
+      metadata: {
+        source_file: 'test.pdf',
+        processed_at: new Date().toISOString(),
+        disciplina_id: 123,
+        component_code: componentCode,
+        component_data: {
+          componentKey: componentCode,
+          subjectKey: 'SUBJ-123',
+          name: 'Test Component',
+          credits: 4,
+          ufComponentId: 123,
+          ufComponentCode: componentCode,
+          campus: 'sbc',
+          shift: 'diurno',
+          vacancies: 40,
+          componentClass: 'A',
+          season: '2026:2',
+          ufClassroomCode: '1234',
+          tpi: { theory: 2, practice: 2, individual: 0 },
+          timetable: [],
+          courses: [],
+          teachers: [
+            { name: 'Test Teacher', role: 'teoria', isSecondary: false },
+          ],
+        },
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/components/metadata',
+      query: { season: '2026:2', componentId: componentCode },
+      payload: { userMessage: 'When is the exam?' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('success');
+    expect(body.data).toEqual(aiResponse);
+
+    const aiSpy = vi.mocked(AIProxyConnector.prototype.requestNaturalResponse);
+    expect(aiSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ component_code: componentCode }),
+      }),
+      'When is the exam?'
+    );
+  });
+});


### PR DESCRIPTION
This pull request introduces a new endpoint, natural language responses to student questions about course components, using official course metadata. The main changes include the creation of a new Mongoose model for course metadata, the addition of a connector to interact with an agent proxy service, and the implementation of a new controller route that ties these pieces together.

**New AI-powered course Q&A endpoint:**

* Added a new POST route `/components/metadata` in `components-controller.ts` that accepts a `componentId` and a user message, retrieves the corresponding course metadata, and returns an AI-generated response tailored to the student's question.

**AI integration and prompt construction:**

* Implemented `requestNaturalResponse` method in `AIProxyConnector` to build a detailed prompt from course metadata and send it to the AI proxy service, ensuring responses use only official course information and follow a friendly, WhatsApp-appropriate style.
* Imported and instantiated `AIProxyConnector` and `ComponentMetadataModel` in the controller to enable the new endpoint.

**Course metadata modeling:**

* Created a new Mongoose schema and model (`ComponentMetadataModel`) in `ComponentMetadata.ts` to represent and query course metadata, including syllabus, evaluation criteria, timetable, and teachers.
* Added an index on `metadata.component_code` to optimize queries by course code.

**Dependency update:**

* Imported the new `ComponentMetadataDocument` type for use in the AI connector.

Linked with: https://github.com/ufabc-next/communications-api-v2/pull/39