### PR TITLE
feat: support both @aluno.ufabc.edu.br and @ufabc.edu.br in check-email

### DIFF
--- a/apps/core/src/routes/users/index.ts
+++ b/apps/core/src/routes/users/index.ts
@@ -1,6 +1,5 @@
-import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi';
-
 import { currentQuad } from '@next/common';
+import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi';
 
 import { UfabcParserConnector } from '@/connectors/ufabc-parser.js';
 import { UfabcParserError } from '@/errors/ufabc-parser.js';
@@ -137,8 +136,6 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       const ufabcParserConnector = new UfabcParserConnector(request.id);
 
       try {
-        
-        // Now accepting both aluno and general UFABC emails @aluno.ufabc and @ufabc.edu
         const student = await ufabcParserConnector.getStudent(ra);
         const hasUfabcContract = await ufabcParserConnector.getTeacher(
           student.login
@@ -146,20 +143,15 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 
         if (hasUfabcContract) {
           return reply.forbidden('O aluno não pode ter contrato com a UFABC.');
-
         }
 
         if (student.email.length > 1) {
-          request.log.warn(
-            {
-              msg: 'User has multiple emails due to employment contract with UFABC or post graduation',
-              ra,
-              emails: student.email,
-            }
-          );
+          request.log.warn({
+            msg: 'User has multiple emails due to employment contract with UFABC or post graduation',
+            ra,
+            emails: student.email,
+          });
         }
-
-       
       } catch (error: unknown) {
         if (error instanceof UfabcParserError) {
           if (error.code === 'UFP0015') {
@@ -289,9 +281,9 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       try {
         const student = await ufabcParserConnector.getStudent(ra);
         await ufabcParserConnector.getTeacher(student.login);
-        const email = student.email.find((e) =>
-          e.includes('@aluno.ufabc.edu.br')
-        );
+        const email =
+          student.email.find((e) => e.endsWith('@aluno.ufabc.edu.br')) ??
+          student.email.find((e) => e.endsWith('@ufabc.edu.br'));
         return reply.send({ email: email! });
       } catch (error) {
         if (error instanceof UfabcParserError) {

--- a/apps/core/src/routes/users/index.ts
+++ b/apps/core/src/routes/users/index.ts
@@ -145,6 +145,16 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           return reply.forbidden('O aluno não pode ter contrato com a UFABC.');
         }
 
+        const normalizedEmail = email.toLowerCase();
+        const emailMatch = student.email.find(
+          (e) => e.toLowerCase() === normalizedEmail
+        );
+        if (!emailMatch) {
+          return reply.badRequest(
+            'O email informado não corresponde ao email institucional vinculado ao RA.'
+          );
+        }
+
         if (student.email.length > 1) {
           request.log.warn({
             msg: 'User has multiple emails due to employment contract with UFABC or post graduation',


### PR DESCRIPTION
## Summary

Fixes `GET /users/check-email` to return `@aluno.ufabc.edu.br` when available, falling back to `@ufabc.edu.br`. Adds email validation in `POST /users/complete` to prevent bypass.

## Changes

- `check-email`: prefers `@aluno.ufabc.edu.br`, falls back to `@ufabc.edu.br`
- `/complete`: validates submitted email against parser's list for the RA
- Removed misleading comment that claimed both were supported

## Related PR

**Must be merged together with:** https://github.com/ufabc-next/ufabc-next-web/pull/496

## Testing

Run the signup flow with both @aluno.ufabc.edu.br and @ufabc.edu.br users. Verify that submitting a mismatched email in /complete is rejected.