### PR TITLE
feat: add lock for /announcement 

### DIFF
--- a/apps/core/src/controllers/proxy-controller.ts
+++ b/apps/core/src/controllers/proxy-controller.ts
@@ -27,9 +27,9 @@ export const proxyController: FastifyPluginAsyncZod = async (app) => {
       const hasLock = await request.acquireLock(lockKey, '24h');
 
       if (!hasLock) {
-        return reply.tooManyRequests(
-          'You can only send one announcement per day'
-        );
+        return reply.status(429).send({
+          message: 'You can only send one announcement per day',
+        });
       }
 
       try {

--- a/apps/core/src/controllers/proxy-controller.ts
+++ b/apps/core/src/controllers/proxy-controller.ts
@@ -1,9 +1,10 @@
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+
 import { z } from 'zod';
 
 import { CommunicationsConnector } from '@/connectors/communications.js';
-import { permissionVerifyHook } from '@/hooks/permission-verify.js';
 import { ALLOWED_ANNOUNCEMENT_PERMISSIONS } from '@/constants.js';
+import { permissionVerifyHook } from '@/hooks/permission-verify.js';
 
 export const proxyController: FastifyPluginAsyncZod = async (app) => {
   app.route({
@@ -18,10 +19,17 @@ export const proxyController: FastifyPluginAsyncZod = async (app) => {
       response: {
         202: z.object({ message: z.string() }),
         429: z.object({ message: z.string() }),
-        502: z.object({ message: z.string() }),
       },
     },
     preHandler: [permissionVerifyHook(ALLOWED_ANNOUNCEMENT_PERMISSIONS)],
+    onError: async (request, _, error) => {
+      const lockKey = `announcement:${request.user._id}`;
+      await request.releaseLock(lockKey);
+      request.log.error(
+        { error, userId: request.user._id },
+        'Failed to send announcement'
+      );
+    },
     handler: async (request, reply) => {
       const lockKey = `announcement:${request.user._id}`;
       const hasLock = await request.acquireLock(lockKey, '24h');
@@ -32,24 +40,13 @@ export const proxyController: FastifyPluginAsyncZod = async (app) => {
         });
       }
 
-      try {
-        const communications = new CommunicationsConnector(
-          app.config.COMMUNICATIONS_API_URL,
-          request.id
-        );
-        const response = await communications.sendAnnouncement(request.body);
+      const communications = new CommunicationsConnector(
+        app.config.COMMUNICATIONS_API_URL,
+        request.id
+      );
+      const response = await communications.sendAnnouncement(request.body);
 
-        return reply.status(202).send(response);
-      } catch (error) {
-        await request.releaseLock(lockKey);
-        request.log.error(
-          { error, userId: request.user._id },
-          'Failed to send announcement'
-        );
-        return reply
-          .status(502)
-          .send({ message: 'Failed to send announcement' });
-      }
+      return reply.status(202).send(response);
     },
   });
 };

--- a/apps/core/src/controllers/proxy-controller.ts
+++ b/apps/core/src/controllers/proxy-controller.ts
@@ -17,18 +17,39 @@ export const proxyController: FastifyPluginAsyncZod = async (app) => {
       }),
       response: {
         202: z.object({ message: z.string() }),
+        429: z.object({ message: z.string() }),
         502: z.object({ message: z.string() }),
       },
     },
     preHandler: [permissionVerifyHook(ALLOWED_ANNOUNCEMENT_PERMISSIONS)],
     handler: async (request, reply) => {
-      const communications = new CommunicationsConnector(
-        app.config.COMMUNICATIONS_API_URL,
-        request.id
-      );
-      const response = await communications.sendAnnouncement(request.body);
+      const lockKey = `announcement:${request.user._id}`;
+      const hasLock = await request.acquireLock(lockKey, '24h');
 
-      return reply.status(202).send(response);
+      if (!hasLock) {
+        return reply.tooManyRequests(
+          'You can only send one announcement per day'
+        );
+      }
+
+      try {
+        const communications = new CommunicationsConnector(
+          app.config.COMMUNICATIONS_API_URL,
+          request.id
+        );
+        const response = await communications.sendAnnouncement(request.body);
+
+        return reply.status(202).send(response);
+      } catch (error) {
+        await request.releaseLock(lockKey);
+        request.log.error(
+          { error, userId: request.user._id },
+          'Failed to send announcement'
+        );
+        return reply
+          .status(502)
+          .send({ message: 'Failed to send announcement' });
+      }
     },
   });
 };


### PR DESCRIPTION
## Changes
- Foi adicionado no proxy-controller.ts o uso do lockKey para realizar o lock per user da chamada do /announcement
- Seguindo o seguinte fluxo:
  1. First call today → lock acquired → announcement sent → 202
  2. Second call within 24h → lock exists → 429 with error message
  3. If the communications API fails → lock is released so the user can retry