### PR TITLE
Fix comment vulnerability

### DIFF
--- a/apps/core/src/routes/comments/index.ts
+++ b/apps/core/src/routes/comments/index.ts
@@ -57,6 +57,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 
   app.post('/', { schema: createCommentSchema }, async (request, reply) => {
     const { enrollment: enrollmentId, comment, type } = request.body;
+    const user = request.user;
 
     if (!comment || !enrollmentId || !type) {
       return reply.badRequest('Body must have all obligatory fields');
@@ -66,6 +67,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 
     if (!enrollment) {
       return reply.notFound('Enrollment not found');
+    }
+
+    if (Number(user.ra) !== Number(enrollment.ra)) {
+      request.log.warn(
+        { userRa: user.ra, commentRa: enrollment.ra },
+        'Unauthorized comment creation attempt'
+      );
+      return reply.forbidden();
     }
 
     if (!enrollment.subject || !enrollment.ra) {
@@ -97,6 +106,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     { schema: updateCommentSchema },
     async (request, reply) => {
       const { commentId } = request.params;
+      const user = request.user;
 
       if (!commentId) {
         request.log.warn({ params: request.params }, 'Missing commentId');
@@ -108,6 +118,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       if (!comment) {
         request.log.warn(comment, 'Comment missing');
         return reply.notFound('Comment not found');
+      }
+
+      if (Number(user.ra) !== Number(comment.ra)) {
+        request.log.warn(
+          { userRa: user.ra, commentRa: comment.ra },
+          'Unauthorized comment update attempt'
+        );
+        return reply.forbidden();
       }
 
       comment.comment = request.body.comment;
@@ -123,6 +141,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     { schema: deleteCommentSchema },
     async (request, reply) => {
       const { commentId } = request.params;
+      const user = request.user;
 
       if (!commentId) {
         request.log.warn({ params: request.params }, 'Missing commentId');
@@ -134,6 +153,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       if (!comment) {
         request.log.warn(comment, 'Comment not found');
         return reply.notFound('Comment not found');
+      }
+
+      if (Number(user.ra) !== Number(comment.ra)) {
+        request.log.warn(
+          { userRa: user.ra, commentRa: comment.ra },
+          'Unauthorized comment delete attempt'
+        );
+        return reply.forbidden();
       }
 
       comment.active = false;


### PR DESCRIPTION
Exploit script that worked before (censored jwt token): 
<img width="1112" height="456" alt="image" src="https://github.com/user-attachments/assets/0e71b6cd-5931-48c6-a046-8f9cf2dd3718" />


As you can see, now we are blocking this unallowed request (backend logs):
<img width="773" height="502" alt="image" src="https://github.com/user-attachments/assets/a62fbd1c-94f6-4979-8e21-cfada37d45af" />