### PR TITLE
Make model use sparse instead of filter expression

### DIFF
--- a/apps/core/src/models/User.ts
+++ b/apps/core/src/models/User.ts
@@ -10,7 +10,7 @@ const userSchema = new Schema(
     ra: {
       type: Number,
       unique: true,
-      partialFilterExpression: { ra: { $exists: true } },
+      sparse: true,
     },
     email: {
       type: String,
@@ -21,7 +21,7 @@ const userSchema = new Schema(
           `${props.value} não é um e-mail válido.`,
       },
       unique: true,
-      partialFilterExpression: { email: { $exists: true } },
+      sparse: true
     },
     confirmed: {
       type: Boolean,


### PR DESCRIPTION
This is because we fixed the mongodb indexes (null were unique problem), and now i'm standartizing the model to be in accordance with the actual db indexes